### PR TITLE
change startedAt entry from job to device

### DIFF
--- a/mysql-init/schema.sql
+++ b/mysql-init/schema.sql
@@ -41,6 +41,7 @@ create table device (
                       'out-of-service'
                     )             not null
 , currentProgress   integer
+, startedAt         timestamp
 , version           varchar(255)  not null
 , lastSeen          timestamp     not null  default current_timestamp
 , primary key (id)
@@ -58,7 +59,6 @@ create table job (
                       'finished'
                     )             not null
 , assignedAt        timestamp     not null  default current_timestamp
-, startedAt         timestamp
 , primary key (id)
 , foreign key (userId) references user(id)
 , foreign key (deviceId) references device(id)


### PR DESCRIPTION
in case of walk-in job that don't create a job first